### PR TITLE
Fix overrides on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
-    name: Test
+  check:
+    name: Project checks
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     steps:
@@ -22,6 +22,21 @@ jobs:
       uses: containerd/project-checks@v1
       with:
         working-directory: src/github.com/containerd/protobuild
+
+  test:
+    name: Test
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, windows-2022 ]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        path: src/github.com/containerd/protobuild
+        fetch-depth: 25
 
     - name: Setup environment
       shell: bash

--- a/main.go
+++ b/main.go
@@ -64,6 +64,14 @@ func parseVersion(s string) (int, error) {
 	return v, nil
 }
 
+func importPath(base, target string) (string, error) {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(rel), nil
+}
+
 func main() {
 	flag.Parse()
 
@@ -199,7 +207,7 @@ func main() {
 			Version:    version,
 		}
 
-		importDirPath, err := filepath.Rel(outputDir, pkg.Dir)
+		importDirPath, err := importPath(outputDir, pkg.Dir)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,31 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestImportPath(t *testing.T) {
+	path, err := importPath("/home/alice/go/src", "/home/alice/go/src/github.com/containerd/foobar")
+	if err != nil {
+		t.Fatalf("got %s", err)
+	}
+
+	expected := "github.com/containerd/foobar"
+	if path != expected {
+		t.Fatalf("got %s, expected %s", path, expected)
+	}
+}


### PR DESCRIPTION
Protobuild was assuming that canonicalized relative file paths and
Go import paths are the same. This is not true on Windows where
the former uses `\` but the latter uses (as like other OSes) `/`.

This change fixes the issue and adds some tests around the
implementation to prevent regressions.

Fixes #47.
