### PR TITLE
Add parameters option for protoc opts

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,6 +32,14 @@ type config struct {
 	// Deprecated: Use Generators instead.
 	Generator string
 
+	// Parameters are custom parameters to be passed to the generators.
+	// The parameter key must be the generator name with a table value
+	// of keys and string values to be passed.
+	// Example:
+	// [parameters.go-ttrpc]
+	// customkey = "somevalue"
+	Parameters map[string]map[string]string
+
 	// Plugins will be deprecated. It has to be per-Generator setting,
 	// but neither protoc-gen-go nor protoc-gen-go-grpc support plugins.
 	// So the refactoring is not worth to do.
@@ -52,6 +60,7 @@ type config struct {
 		// Deprecated: Use Generators instead.
 		Generator  string
 		Generators []string
+		Parameters map[string]map[string]string
 		Plugins    *[]string
 
 		// TODO(stevvooe): We could probably support overriding of includes and

--- a/protoc_test.go
+++ b/protoc_test.go
@@ -27,21 +27,43 @@ func TestMkcmd(t *testing.T) {
 	}{
 		{
 			name:       "basic",
-			cmd:        protocCmd{Names: []string{"go"}},
+			cmd:        protocCmd{Names: []string{"go"}, Generators: []generator{{Name: "go"}}},
 			expectedV1: "protoc -I --go_out=import_path=:",
 			expectedV2: "protoc -I --go_out=",
 		},
 		{
 			name:       "plugin",
-			cmd:        protocCmd{Names: []string{"go"}, Plugins: []string{"grpc"}},
+			cmd:        protocCmd{Names: []string{"go"}, Plugins: []string{"grpc"}, Generators: []generator{{Name: "go"}}},
 			expectedV1: "protoc -I --go_out=plugins=grpc,import_path=:",
 			expectedV2: "protoc -I --go_out=",
 		},
 		{
 			name:       "use protoc-gen-go-grpc instead of plugins",
-			cmd:        protocCmd{Names: []string{"go", "go-grpc"}},
+			cmd:        protocCmd{Names: []string{"go", "go-grpc"}, Generators: []generator{{Name: "go"}, {Name: "go-grpc"}}},
 			expectedV1: "protoc -I --go_out=import_path=: --go-grpc_out=import_path=:",
 			expectedV2: "protoc -I --go_out= --go-grpc_out=",
+		},
+		{
+			name: "use custom parameters",
+			cmd: protocCmd{
+				Names: []string{"go", "go-ttrpc"},
+				Generators: []generator{
+					{
+						Name: "go",
+						Parameters: map[string]string{
+							"Mpath": "newpath",
+						},
+					},
+					{
+						Name: "go-ttrpc",
+						Parameters: map[string]string{
+							"prefix": "TTRPC",
+						},
+					},
+				},
+			},
+			expectedV1: "protoc -I --go_out=import_path=: --go-ttrpc_out=import_path=:",
+			expectedV2: "protoc -I --go_out= --go_opt=Mpath=newpath --go-ttrpc_out= --go-ttrpc_opt=prefix=TTRPC",
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
Adds support for custom parameters to be passed to the protoc generators.

This is part of an effort to generate ttrpc services alongside existing grpc services. A custom parameter will be added to the ttrpc generator which allows prefixing the TTRPC service names when they are generated.

Configuration would look something like...
```.toml
[parameters.go-ttrpc]
prefix = "TTRPC"
```