### PR TITLE
support paths=source_relative

### DIFF
--- a/Protobuild.toml
+++ b/Protobuild.toml
@@ -10,6 +10,15 @@ version = "unstable"
 # The common example grpc is provided below.
 plugins = ["grpc"]
 
+# protoc-gen-go supports several output modes which control where generated
+# .pb.go files are placed.  The default "import" mode creates a directory tree
+# corresponding to the Go package specified in the .proto file.  This mode is
+# appropriate when working inside the GOPATH.  The "source_relative" mode may
+# be useful if you want your .pb.go files to be in the same directory as your
+# .proto files, which can be useful when working outside the GOPATH on a module.
+# See https://developers.google.com/protocol-buffers/docs/reference/go-generated#invocation
+output_mode = "source_relative"
+
 # Control protoc include paths. Below are usually some good defaults, but feel
 # free to try it without them if it works for your project.
 [includes]

--- a/config.go
+++ b/config.go
@@ -44,6 +44,8 @@ type config struct {
 		After    []string
 	}
 
+	OutputMode string `toml:"output_mode"`
+
 	Packages map[string]string
 
 	Overrides []struct {

--- a/main.go
+++ b/main.go
@@ -202,6 +202,7 @@ func main() {
 			PackageMap: c.Packages,
 			Plugins:    c.Plugins,
 			Files:      pkg.ProtoFiles,
+			OutputMode: c.OutputMode,
 			OutputDir:  outputDir,
 			Includes:   includes,
 			Version:    version,

--- a/protoc.go
+++ b/protoc.go
@@ -42,6 +42,8 @@ var (
 		{{- range $proto, $gopkg := .PackageMap }} --go_opt=M
 			{{- $proto}}={{$gopkg -}}
 		{{- end -}}
+
+		{{- if ne .OutputMode "" }} --go_opt=paths={{ .OutputMode }}{{- end -}}
 	{{- end -}}
 
 	{{- range .Files}} {{.}}{{end -}}
@@ -57,6 +59,7 @@ type protocCmd struct {
 	ImportPath  string
 	PackageMap  map[string]string
 	Files       []string
+	OutputMode  string
 	OutputDir   string
 	// Version is Protobuild's version.
 	Version int
@@ -91,6 +94,10 @@ func (p *protocCmd) GoOutV1() string {
 
 // GoOutV2 returns the parameter for --go_out= for protoc-gen-go >= 1.4.0.
 func (p *protocCmd) GoOutV2() string {
+	if p.OutputMode == "source_relative" {
+		path, _ := os.Getwd()
+		return path
+	}
 	return p.OutputDir
 }
 


### PR DESCRIPTION
paths=source_relative enables protobuild to work when a project is checked out to a directory not located in the GOPATH.
